### PR TITLE
feat(docker-compose): add otlp header

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,7 @@ SG_ENV=development
 
 # OpenTelemetry
 
+# OTEL_EXPORTER_OTLP_HEADERS="<provider-specific-header>=<API key>"
 # OTEL_EXPORTER_OTLP_ENDPOINT=<OpenTelemetry provider URL>
 # OTEL_EXPORTER_OTLP_API_KEY=<OpenTelemetry provider API key>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ x-influxdb-client-env: &influxdb-client-env
   INFLUX_ORG: ${INFLUX_ORG:-PlaceOS}
 
 x-opentelemetry-env: &opentelemetry-env
+  OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
   OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
   OTEL_EXPORTER_OTLP_API_KEY: ${OTEL_EXPORTER_OTLP_API_KEY:-}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,6 +263,7 @@ services:
       - *jwt-public-key-env
       - *secret-key-env
     environment:
+      <<: *opentelemetry-env
       <<: *redis-client-env
       SG_ENV: production
       STAFF_TIME_ZONE: $TZ


### PR DESCRIPTION
**Description of the change**

Some providers have custom api key headers. Using the OTEL_EXPORTER_OTLP_HEADER allows you to set these at your leisure.