### PR TITLE
chore(core): persist drivers and repos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ volumes:
   postgres-data:
   redis-data:
   rethink-data:
-  core-repos:
+  core-repositories:
   core-drivers:
   www:
 
@@ -156,7 +156,7 @@ services:
       - rethink
     volumes:
       - type: volume
-        source: core-repos
+        source: core-repositories
         target: /app/repositories/
       - type: volume
         source: core-drivers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ volumes:
   postgres-data:
   redis-data:
   rethink-data:
+  core-repos:
+  core-drivers:
   www:
 
 # YAML Anchors
@@ -152,6 +154,13 @@ services:
       - etcd
       - redis
       - rethink
+    volumes:
+      - type: volume
+        source: core-repos
+        target: /app/repositories/
+      - type: volume
+        source: core-drivers
+        target: /app/bin/drivers/
     env_file:
       - *secret-key-env
     ulimits:


### PR DESCRIPTION
Persist core drivers and repos in named volumes.

This config used to be present but I removed it because I thought it was the default behaviour after core's Dockerfile specified `VOLUME` https://github.com/PlaceOS/core/blob/master/Dockerfile#L116

However based on tests it looks like my understanding of docker behaviour is wrong. In order for the files to persist container recreation (placeos version upgrades), the volumes must be NAMED.
