### PR TITLE
feat(docker-compose): use an init for `core` container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,6 +164,7 @@ services:
 
   core: # Module coordinator
     image: ${CONTAINER_REGISTRY:-docker.io}/placeos/core:${PLACE_CORE_TAG:-latest}
+    init: true # An init process prevents leaking of PlaceOS Driver processes
     restart: always
     container_name: core
     hostname: core


### PR DESCRIPTION
**Description of the change**

Adds an init script to the core container.

**Benefits**

The init script runs as the root process, cleaning up zombie processes on exit