### PR TITLE
fix(docker-compose): use keydb-cli instead of redis-cli in heathcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -519,7 +519,7 @@ services:
     container_name: redis
     hostname: redis
     healthcheck:
-      test: redis-cli ping
+      test: keydb-cli ping
     <<: *std-network
     <<: *std-logging
     volumes:


### PR DESCRIPTION
**Description of the change**

Change the healthcheck line in `docker-compose.yaml` to use keydb-cli rather than redis-cli as the latter no longer exists (meaning the container is marked as unhealthy).

**Benefits**

Container's health is accurately reported.