### PR TITLE
fix(docker-compose): update health check script to avoid 405 errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -393,7 +393,7 @@ services:
     container_name: elastic
     hostname: elastic
     healthcheck:
-      test: wget -q --no-verbose --tries=1 --spider http://localhost:9200/_cat/health
+      test: curl --silent --fail localhost:9200/_cat/health
       start_period: 1m
     <<: *std-network
     <<: *std-logging


### PR DESCRIPTION
**Description of the change**

Change `elastic` container health check script with `curl` without relying on the server to support **HEAD** requests. Previous `wget --spider` was failing with **405 Method Not Allowed**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Container's health is accurately reported.